### PR TITLE
feat(agents): add Dev agent integration

### DIFF
--- a/src/agents/dev.ts
+++ b/src/agents/dev.ts
@@ -1,0 +1,461 @@
+import * as fs from "fs";
+import * as path from "path";
+import { spawnAgent, runAgent, AgentResult, AgentHandle, isSuccess, isBlocked, isError } from "./base";
+import { ORCHESTRATOR_DIR } from "../types";
+import { findLatestUnansweredQuestion, parseQuestionFile, routeQuestion } from "../blocking";
+
+/**
+ * Dev Agent constants
+ */
+export const DEV_PROMPT_FILE = "prompts/dev.md";
+export const PRD_FILE = path.join(ORCHESTRATOR_DIR, "prd.md");
+export const ARCHITECTURE_FILE = path.join(ORCHESTRATOR_DIR, "architecture.md");
+
+/**
+ * Configuration for running a Dev agent
+ */
+export interface DevAgentConfig {
+  /** Area this Dev session handles (e.g., "frontend", "backend") */
+  area: string;
+  /** Ticket numbers assigned to this Dev session */
+  tickets: number[];
+  /** Path to PRD file (defaults to ".orchestrator/prd.md") */
+  prdFile?: string;
+  /** Path to architecture file (defaults to ".orchestrator/architecture.md") */
+  architectureFile?: string;
+  /** Path to Dev prompt file (defaults to "prompts/dev.md") */
+  promptFile?: string;
+  /** Additional context to pass to Dev */
+  additionalContext?: string;
+}
+
+/**
+ * Result from Dev agent execution
+ */
+export interface DevAgentResult {
+  /** The area this Dev session handled */
+  area: string;
+  /** The underlying agent result */
+  agentResult: AgentResult;
+  /** Status: "success" | "blocked" | "error" */
+  status: "success" | "blocked" | "error";
+  /** Question file path if blocked */
+  questionFile: string | null;
+  /** Whether the question is for Tech Lead */
+  needsTechLead: boolean;
+}
+
+/**
+ * Handle to a running Dev agent
+ */
+export interface DevSessionHandle {
+  /** The area this Dev session handles */
+  area: string;
+  /** The underlying agent handle */
+  agentHandle: AgentHandle;
+  /** Ticket numbers assigned to this session */
+  tickets: number[];
+  /** Promise that resolves with the Dev agent result */
+  result: Promise<DevAgentResult>;
+}
+
+/**
+ * Error thrown for Dev agent operations
+ */
+export class DevAgentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DevAgentError";
+  }
+}
+
+/**
+ * Read PRD file content
+ * @throws DevAgentError if PRD doesn't exist
+ */
+export function readPRDFile(prdFile: string = PRD_FILE): string {
+  if (!fs.existsSync(prdFile)) {
+    throw new DevAgentError(`PRD file not found: ${prdFile}`);
+  }
+  return fs.readFileSync(prdFile, "utf-8");
+}
+
+/**
+ * Read architecture file content
+ * @throws DevAgentError if architecture file doesn't exist
+ */
+export function readArchitectureFile(architectureFile: string = ARCHITECTURE_FILE): string {
+  if (!fs.existsSync(architectureFile)) {
+    throw new DevAgentError(`Architecture file not found: ${architectureFile}`);
+  }
+  return fs.readFileSync(architectureFile, "utf-8");
+}
+
+/**
+ * Build context for Dev agent from area, PRD, architecture, and tickets
+ */
+export function buildDevContext(
+  area: string,
+  tickets: number[],
+  prdContent: string,
+  architectureContent: string,
+  additionalContext?: string
+): string {
+  const parts: string[] = [];
+
+  parts.push("# Your Assignment");
+  parts.push("");
+  parts.push(`Area: ${area}`);
+  parts.push(`Tickets: ${tickets.map((t) => `#${t}`).join(", ")}`);
+
+  parts.push("");
+  parts.push("# PRD (Product Requirements Document)");
+  parts.push("");
+  parts.push(prdContent);
+
+  parts.push("");
+  parts.push("# Architecture");
+  parts.push("");
+  parts.push(architectureContent);
+
+  if (additionalContext && additionalContext.trim() !== "") {
+    parts.push("");
+    parts.push("# Additional Context");
+    parts.push("");
+    parts.push(additionalContext);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Ensure the orchestrator directory exists
+ */
+function ensureOrchestratorDir(): void {
+  if (!fs.existsSync(ORCHESTRATOR_DIR)) {
+    fs.mkdirSync(ORCHESTRATOR_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Check if a blocked Dev needs Tech Lead
+ * Returns the question file and routing info
+ */
+export function checkBlockingForTechLead(): {
+  questionFile: string | null;
+  needsTechLead: boolean;
+} {
+  const questionFile = findLatestUnansweredQuestion();
+
+  if (!questionFile) {
+    return { questionFile: null, needsTechLead: false };
+  }
+
+  const parsedQuestion = parseQuestionFile(questionFile);
+  const routing = routeQuestion(parsedQuestion);
+
+  return {
+    questionFile,
+    needsTechLead: routing === "spawn_tech_lead",
+  };
+}
+
+/**
+ * Convert agent result to Dev agent result
+ */
+function toDevAgentResult(
+  area: string,
+  agentResult: AgentResult
+): DevAgentResult {
+  let status: DevAgentResult["status"];
+  let questionFile: string | null = null;
+  let needsTechLead = false;
+
+  if (isSuccess(agentResult)) {
+    status = "success";
+  } else if (isBlocked(agentResult)) {
+    status = "blocked";
+    const blockingInfo = checkBlockingForTechLead();
+    questionFile = blockingInfo.questionFile;
+    needsTechLead = blockingInfo.needsTechLead;
+  } else {
+    status = "error";
+  }
+
+  return {
+    area,
+    agentResult,
+    status,
+    questionFile,
+    needsTechLead,
+  };
+}
+
+/**
+ * Run a Dev agent for a specific area
+ *
+ * Spawns a Dev agent in background mode (stdio: "pipe").
+ * The Dev reads the PRD, architecture, and ticket list, then implements.
+ *
+ * @param config - Dev agent configuration
+ * @returns Promise that resolves with the Dev agent result
+ *
+ * @example
+ * const result = await runDevAgent({
+ *   area: "frontend",
+ *   tickets: [10, 11, 12]
+ * });
+ * if (result.status === "blocked" && result.needsTechLead) {
+ *   // Route to Tech Lead
+ * }
+ */
+export async function runDevAgent(
+  config: DevAgentConfig
+): Promise<DevAgentResult> {
+  const {
+    area,
+    tickets,
+    prdFile = PRD_FILE,
+    architectureFile = ARCHITECTURE_FILE,
+    promptFile = DEV_PROMPT_FILE,
+    additionalContext,
+  } = config;
+
+  // Validate configuration
+  if (!area || area.trim() === "") {
+    throw new DevAgentError("Area is required");
+  }
+
+  if (!tickets || tickets.length === 0) {
+    throw new DevAgentError("At least one ticket is required");
+  }
+
+  // Ensure orchestrator directory exists
+  ensureOrchestratorDir();
+
+  // Validate prompt file exists
+  if (!fs.existsSync(promptFile)) {
+    throw new DevAgentError(`Dev prompt file not found: ${promptFile}`);
+  }
+
+  // Read PRD and architecture, build context
+  const prdContent = readPRDFile(prdFile);
+  const architectureContent = readArchitectureFile(architectureFile);
+  const context = buildDevContext(area, tickets, prdContent, architectureContent, additionalContext);
+
+  // Run Dev agent in background mode (capture output)
+  const agentResult = await runAgent({
+    name: `dev-${area}`,
+    promptFile,
+    context,
+    stdio: "pipe",
+  });
+
+  return toDevAgentResult(area, agentResult);
+}
+
+/**
+ * Spawn a Dev agent without waiting for completion
+ *
+ * Returns a handle that can be used to monitor or kill the process.
+ * Useful for running multiple Dev sessions in parallel.
+ *
+ * @param config - Dev agent configuration
+ * @returns Dev session handle with process and result promise
+ *
+ * @example
+ * // Spawn multiple Dev sessions in parallel
+ * const handles = areas.map(area => spawnDevAgent({ area, tickets: [...] }));
+ * const results = await Promise.all(handles.map(h => h.result));
+ */
+export function spawnDevAgent(config: DevAgentConfig): DevSessionHandle {
+  const {
+    area,
+    tickets,
+    prdFile = PRD_FILE,
+    architectureFile = ARCHITECTURE_FILE,
+    promptFile = DEV_PROMPT_FILE,
+    additionalContext,
+  } = config;
+
+  // Validate configuration
+  if (!area || area.trim() === "") {
+    throw new DevAgentError("Area is required");
+  }
+
+  if (!tickets || tickets.length === 0) {
+    throw new DevAgentError("At least one ticket is required");
+  }
+
+  // Ensure orchestrator directory exists
+  ensureOrchestratorDir();
+
+  // Validate prompt file exists
+  if (!fs.existsSync(promptFile)) {
+    throw new DevAgentError(`Dev prompt file not found: ${promptFile}`);
+  }
+
+  // Read PRD and architecture, build context
+  const prdContent = readPRDFile(prdFile);
+  const architectureContent = readArchitectureFile(architectureFile);
+  const context = buildDevContext(area, tickets, prdContent, architectureContent, additionalContext);
+
+  // Spawn Dev agent in background mode
+  const agentHandle = spawnAgent({
+    name: `dev-${area}`,
+    promptFile,
+    context,
+    stdio: "pipe",
+  });
+
+  // Create result promise that wraps the agent result
+  const result = agentHandle.result.then((agentResult) =>
+    toDevAgentResult(area, agentResult)
+  );
+
+  return {
+    area,
+    agentHandle,
+    tickets,
+    result,
+  };
+}
+
+/**
+ * Input for running multiple Dev sessions
+ */
+export interface DevSessionInput {
+  area: string;
+  tickets: number[];
+}
+
+/**
+ * Options for running multiple Dev sessions
+ */
+export interface RunDevSessionsOptions {
+  /** Whether to run sessions in parallel (default: true) */
+  parallel?: boolean;
+  /** Path to PRD file */
+  prdFile?: string;
+  /** Path to architecture file */
+  architectureFile?: string;
+  /** Path to Dev prompt file */
+  promptFile?: string;
+}
+
+/**
+ * Run multiple Dev sessions
+ *
+ * Spawns Dev agents for each area. By default runs in parallel.
+ *
+ * @param sessions - Array of session inputs with area and tickets
+ * @param options - Options for running sessions
+ * @returns Promise that resolves with array of Dev agent results
+ *
+ * @example
+ * const results = await runDevSessions([
+ *   { area: "frontend", tickets: [10, 11] },
+ *   { area: "backend", tickets: [12, 13] }
+ * ]);
+ *
+ * // Check for any blocked sessions needing Tech Lead
+ * const blockedForTechLead = results.filter(r =>
+ *   r.status === "blocked" && r.needsTechLead
+ * );
+ */
+export async function runDevSessions(
+  sessions: DevSessionInput[],
+  options: RunDevSessionsOptions = {}
+): Promise<DevAgentResult[]> {
+  const {
+    parallel = true,
+    prdFile,
+    architectureFile,
+    promptFile,
+  } = options;
+
+  if (sessions.length === 0) {
+    return [];
+  }
+
+  if (parallel) {
+    // Spawn all sessions and wait for all to complete
+    const handles = sessions.map((session) =>
+      spawnDevAgent({
+        area: session.area,
+        tickets: session.tickets,
+        prdFile,
+        architectureFile,
+        promptFile,
+      })
+    );
+
+    return Promise.all(handles.map((h) => h.result));
+  } else {
+    // Run sessions sequentially
+    const results: DevAgentResult[] = [];
+    for (const session of sessions) {
+      const result = await runDevAgent({
+        area: session.area,
+        tickets: session.tickets,
+        prdFile,
+        architectureFile,
+        promptFile,
+      });
+      results.push(result);
+    }
+    return results;
+  }
+}
+
+/**
+ * Spawn multiple Dev sessions without waiting
+ *
+ * Returns handles for all sessions that can be individually monitored.
+ *
+ * @param sessions - Array of session inputs
+ * @param options - Options for spawning sessions
+ * @returns Array of Dev session handles
+ */
+export function spawnDevSessions(
+  sessions: DevSessionInput[],
+  options: RunDevSessionsOptions = {}
+): DevSessionHandle[] {
+  const { prdFile, architectureFile, promptFile } = options;
+
+  return sessions.map((session) =>
+    spawnDevAgent({
+      area: session.area,
+      tickets: session.tickets,
+      prdFile,
+      architectureFile,
+      promptFile,
+    })
+  );
+}
+
+/**
+ * Get the first blocked session that needs Tech Lead intervention
+ */
+export function getBlockedSessionForTechLead(
+  results: DevAgentResult[]
+): DevAgentResult | null {
+  return results.find((r) => r.status === "blocked" && r.needsTechLead) || null;
+}
+
+/**
+ * Check if all sessions completed successfully
+ */
+export function allSessionsCompleted(results: DevAgentResult[]): boolean {
+  return results.every((r) => r.status === "success");
+}
+
+/**
+ * Get sessions by status
+ */
+export function getSessionsByStatus(
+  results: DevAgentResult[],
+  status: DevAgentResult["status"]
+): DevAgentResult[] {
+  return results.filter((r) => r.status === status);
+}

--- a/tests/agents/dev.test.ts
+++ b/tests/agents/dev.test.ts
@@ -1,0 +1,828 @@
+import * as fs from "fs";
+import * as path from "path";
+import { EventEmitter } from "events";
+import { ChildProcess } from "child_process";
+import {
+  DevAgentConfig,
+  DevAgentError,
+  DevAgentResult,
+  DEV_PROMPT_FILE,
+  PRD_FILE,
+  ARCHITECTURE_FILE,
+  readPRDFile,
+  readArchitectureFile,
+  buildDevContext,
+  checkBlockingForTechLead,
+  runDevAgent,
+  spawnDevAgent,
+  runDevSessions,
+  spawnDevSessions,
+  getBlockedSessionForTechLead,
+  allSessionsCompleted,
+  getSessionsByStatus,
+} from "../../src/agents/dev";
+import { EXIT_CODES } from "../../src/blocking";
+
+// Test directory for isolation
+const TEST_DIR = path.join(__dirname, ".test-dev-agent");
+const TEST_PROMPTS_DIR = path.join(TEST_DIR, "prompts");
+const TEST_ORCHESTRATOR_DIR = path.join(TEST_DIR, ".orchestrator");
+const TEST_QUESTIONS_DIR = path.join(TEST_ORCHESTRATOR_DIR, "questions");
+
+// Mock child_process
+jest.mock("child_process", () => {
+  const originalModule = jest.requireActual("child_process");
+  return {
+    ...originalModule,
+    spawn: jest.fn(),
+  };
+});
+
+// Mock types to use test directory
+jest.mock("../../src/types", () => {
+  const originalModule = jest.requireActual("../../src/types");
+  const testDir = require("path").join(__dirname, ".test-dev-agent");
+  return {
+    ...originalModule,
+    ORCHESTRATOR_DIR: require("path").join(testDir, ".orchestrator"),
+  };
+});
+
+// Mock blocking module for question routing tests
+jest.mock("../../src/blocking", () => {
+  const originalModule = jest.requireActual("../../src/blocking");
+  return {
+    ...originalModule,
+    findLatestUnansweredQuestion: jest.fn(),
+    parseQuestionFile: jest.fn(),
+    routeQuestion: jest.fn(),
+  };
+});
+
+// Get the mocked spawn
+import { spawn as mockSpawn } from "child_process";
+const mockedSpawn = mockSpawn as jest.MockedFunction<typeof mockSpawn>;
+
+// Get mocked blocking functions
+import {
+  findLatestUnansweredQuestion,
+  parseQuestionFile,
+  routeQuestion,
+} from "../../src/blocking";
+const mockedFindLatestUnansweredQuestion = findLatestUnansweredQuestion as jest.MockedFunction<
+  typeof findLatestUnansweredQuestion
+>;
+const mockedParseQuestionFile = parseQuestionFile as jest.MockedFunction<
+  typeof parseQuestionFile
+>;
+const mockedRouteQuestion = routeQuestion as jest.MockedFunction<
+  typeof routeQuestion
+>;
+
+// Helper to create a mock child process
+function createMockProcess(exitCode: number = 0): ChildProcess {
+  const process = new EventEmitter() as ChildProcess;
+  (process as any).stdout = new EventEmitter();
+  (process as any).stderr = new EventEmitter();
+  (process as any).killed = false;
+  (process as any).pid = 12345;
+
+  (process as any).kill = jest.fn((signal?: string) => {
+    (process as any).killed = true;
+    process.emit("close", null, signal || "SIGTERM");
+    return true;
+  });
+
+  // Emit close after a tick
+  setImmediate(() => {
+    if (!(process as any).killed) {
+      process.emit("close", exitCode, null);
+    }
+  });
+
+  return process;
+}
+
+describe("Dev Agent", () => {
+  beforeEach(() => {
+    // Clean up and create test directory
+    if (fs.existsSync(TEST_DIR)) {
+      fs.rmSync(TEST_DIR, { recursive: true });
+    }
+    fs.mkdirSync(TEST_PROMPTS_DIR, { recursive: true });
+    fs.mkdirSync(TEST_ORCHESTRATOR_DIR, { recursive: true });
+    fs.mkdirSync(TEST_QUESTIONS_DIR, { recursive: true });
+
+    // Reset mocks
+    mockedSpawn.mockReset();
+    mockedFindLatestUnansweredQuestion.mockReset();
+    mockedParseQuestionFile.mockReset();
+    mockedRouteQuestion.mockReset();
+  });
+
+  afterAll(() => {
+    // Clean up test directory
+    if (fs.existsSync(TEST_DIR)) {
+      fs.rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  describe("readPRDFile", () => {
+    it("should read PRD content", () => {
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      fs.writeFileSync(prdPath, "# PRD\n\n## Features");
+
+      const content = readPRDFile(prdPath);
+
+      expect(content).toBe("# PRD\n\n## Features");
+    });
+
+    it("should throw DevAgentError if PRD not found", () => {
+      expect(() => readPRDFile("/nonexistent/prd.md")).toThrow(DevAgentError);
+      expect(() => readPRDFile("/nonexistent/prd.md")).toThrow(
+        "PRD file not found"
+      );
+    });
+  });
+
+  describe("readArchitectureFile", () => {
+    it("should read architecture content", () => {
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+      fs.writeFileSync(archPath, "# Architecture\n\n## Components");
+
+      const content = readArchitectureFile(archPath);
+
+      expect(content).toBe("# Architecture\n\n## Components");
+    });
+
+    it("should throw DevAgentError if architecture not found", () => {
+      expect(() => readArchitectureFile("/nonexistent/architecture.md")).toThrow(
+        DevAgentError
+      );
+      expect(() => readArchitectureFile("/nonexistent/architecture.md")).toThrow(
+        "Architecture file not found"
+      );
+    });
+  });
+
+  describe("buildDevContext", () => {
+    it("should build context with area, tickets, PRD, and architecture", () => {
+      const context = buildDevContext(
+        "frontend",
+        [10, 11, 12],
+        "# PRD Content",
+        "# Arch Content"
+      );
+
+      expect(context).toContain("# Your Assignment");
+      expect(context).toContain("Area: frontend");
+      expect(context).toContain("Tickets: #10, #11, #12");
+      expect(context).toContain("# PRD (Product Requirements Document)");
+      expect(context).toContain("# PRD Content");
+      expect(context).toContain("# Architecture");
+      expect(context).toContain("# Arch Content");
+      expect(context).not.toContain("# Additional Context");
+    });
+
+    it("should include additional context when provided", () => {
+      const context = buildDevContext(
+        "backend",
+        [20],
+        "PRD",
+        "Arch",
+        "Extra instructions"
+      );
+
+      expect(context).toContain("# Additional Context");
+      expect(context).toContain("Extra instructions");
+    });
+
+    it("should ignore empty additional context", () => {
+      const context = buildDevContext("api", [1], "PRD", "Arch", "   ");
+
+      expect(context).not.toContain("# Additional Context");
+    });
+  });
+
+  describe("checkBlockingForTechLead", () => {
+    it("should return needsTechLead true when question routes to tech_lead", () => {
+      const questionFile = path.join(TEST_QUESTIONS_DIR, "q-001.md");
+      mockedFindLatestUnansweredQuestion.mockReturnValue(questionFile);
+      mockedParseQuestionFile.mockReturnValue({
+        filePath: questionFile,
+        fromAgent: "dev-frontend",
+        forRecipient: "tech_lead",
+        context: "",
+        question: "How to structure?",
+        options: [],
+        rawContent: "",
+      });
+      mockedRouteQuestion.mockReturnValue("spawn_tech_lead");
+
+      const result = checkBlockingForTechLead();
+
+      expect(result.questionFile).toBe(questionFile);
+      expect(result.needsTechLead).toBe(true);
+    });
+
+    it("should return needsTechLead false when question routes to user", () => {
+      const questionFile = path.join(TEST_QUESTIONS_DIR, "q-002.md");
+      mockedFindLatestUnansweredQuestion.mockReturnValue(questionFile);
+      mockedParseQuestionFile.mockReturnValue({
+        filePath: questionFile,
+        fromAgent: "dev-frontend",
+        forRecipient: "user",
+        context: "",
+        question: "Which approach?",
+        options: [],
+        rawContent: "",
+      });
+      mockedRouteQuestion.mockReturnValue("prompt_user");
+
+      const result = checkBlockingForTechLead();
+
+      expect(result.questionFile).toBe(questionFile);
+      expect(result.needsTechLead).toBe(false);
+    });
+
+    it("should return null questionFile when no unanswered questions", () => {
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      const result = checkBlockingForTechLead();
+
+      expect(result.questionFile).toBeNull();
+      expect(result.needsTechLead).toBe(false);
+    });
+  });
+
+  describe("runDevAgent", () => {
+    const setupTestFiles = () => {
+      const promptPath = path.join(TEST_PROMPTS_DIR, "dev.md");
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+
+      fs.writeFileSync(promptPath, "You are a Dev agent");
+      fs.writeFileSync(prdPath, "# PRD\n\n## Features");
+      fs.writeFileSync(archPath, "# Architecture\n\n## Components");
+
+      return { promptPath, prdPath, archPath };
+    };
+
+    it("should run Dev agent and return success when exit code 0", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.SUCCESS);
+      mockedSpawn.mockReturnValue(mockProcess);
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      const result = await runDevAgent({
+        area: "frontend",
+        tickets: [10, 11],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      expect(result.area).toBe("frontend");
+      expect(result.status).toBe("success");
+      expect(result.agentResult.exitCode).toBe(0);
+      expect(result.questionFile).toBeNull();
+      expect(result.needsTechLead).toBe(false);
+    });
+
+    it("should spawn agent with pipe stdio (background)", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.SUCCESS);
+      mockedSpawn.mockReturnValue(mockProcess);
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      await runDevAgent({
+        area: "backend",
+        tickets: [20],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        "claude",
+        expect.any(Array),
+        expect.objectContaining({
+          stdio: "pipe",
+        })
+      );
+    });
+
+    it("should pass area, tickets, PRD, and architecture in context", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.SUCCESS);
+      mockedSpawn.mockReturnValue(mockProcess);
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      await runDevAgent({
+        area: "api",
+        tickets: [1, 2, 3],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      const callArgs = mockedSpawn.mock.calls[0][1];
+      const contextIndex = callArgs.indexOf("--context");
+      expect(contextIndex).toBeGreaterThan(-1);
+
+      const contextValue = callArgs[contextIndex + 1];
+      expect(contextValue).toContain("Area: api");
+      expect(contextValue).toContain("Tickets: #1, #2, #3");
+      expect(contextValue).toContain("# PRD");
+      expect(contextValue).toContain("# Architecture");
+    });
+
+    it("should return blocked status with Tech Lead routing for exit code 2", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.BLOCKED);
+      mockedSpawn.mockReturnValue(mockProcess);
+
+      const questionFile = path.join(TEST_QUESTIONS_DIR, "q-001.md");
+      mockedFindLatestUnansweredQuestion.mockReturnValue(questionFile);
+      mockedParseQuestionFile.mockReturnValue({
+        filePath: questionFile,
+        fromAgent: "dev-frontend",
+        forRecipient: "tech_lead",
+        context: "",
+        question: "Architecture question",
+        options: [],
+        rawContent: "",
+      });
+      mockedRouteQuestion.mockReturnValue("spawn_tech_lead");
+
+      const result = await runDevAgent({
+        area: "frontend",
+        tickets: [10],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      expect(result.status).toBe("blocked");
+      expect(result.agentResult.exitCode).toBe(2);
+      expect(result.questionFile).toBe(questionFile);
+      expect(result.needsTechLead).toBe(true);
+    });
+
+    it("should return error status for exit code 1", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.ERROR);
+      mockedSpawn.mockReturnValue(mockProcess);
+
+      const result = await runDevAgent({
+        area: "frontend",
+        tickets: [10],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      expect(result.status).toBe("error");
+      expect(result.agentResult.exitCode).toBe(1);
+    });
+
+    it("should throw DevAgentError if area is empty", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+
+      await expect(
+        runDevAgent({
+          area: "",
+          tickets: [10],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow(DevAgentError);
+      await expect(
+        runDevAgent({
+          area: "",
+          tickets: [10],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow("Area is required");
+    });
+
+    it("should throw DevAgentError if tickets array is empty", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+
+      await expect(
+        runDevAgent({
+          area: "frontend",
+          tickets: [],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow(DevAgentError);
+      await expect(
+        runDevAgent({
+          area: "frontend",
+          tickets: [],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow("At least one ticket is required");
+    });
+
+    it("should throw DevAgentError if prompt file not found", async () => {
+      const { prdPath, archPath } = setupTestFiles();
+
+      await expect(
+        runDevAgent({
+          area: "frontend",
+          tickets: [10],
+          promptFile: "/nonexistent/prompt.md",
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow(DevAgentError);
+    });
+
+    it("should throw DevAgentError if PRD not found", async () => {
+      const { promptPath, archPath } = setupTestFiles();
+
+      await expect(
+        runDevAgent({
+          area: "frontend",
+          tickets: [10],
+          promptFile: promptPath,
+          prdFile: "/nonexistent/prd.md",
+          architectureFile: archPath,
+        })
+      ).rejects.toThrow(DevAgentError);
+    });
+
+    it("should throw DevAgentError if architecture not found", async () => {
+      const { promptPath, prdPath } = setupTestFiles();
+
+      await expect(
+        runDevAgent({
+          area: "frontend",
+          tickets: [10],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: "/nonexistent/architecture.md",
+        })
+      ).rejects.toThrow(DevAgentError);
+    });
+
+    it("should include additional context if provided", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+      const mockProcess = createMockProcess(EXIT_CODES.SUCCESS);
+      mockedSpawn.mockReturnValue(mockProcess);
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      await runDevAgent({
+        area: "frontend",
+        tickets: [10],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+        additionalContext: "Focus on performance",
+      });
+
+      const callArgs = mockedSpawn.mock.calls[0][1];
+      const contextIndex = callArgs.indexOf("--context");
+      const contextValue = callArgs[contextIndex + 1];
+      expect(contextValue).toContain("# Additional Context");
+      expect(contextValue).toContain("Focus on performance");
+    });
+  });
+
+  describe("spawnDevAgent", () => {
+    it("should spawn agent and return handle", () => {
+      const promptPath = path.join(TEST_PROMPTS_DIR, "dev.md");
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+      fs.writeFileSync(promptPath, "prompt");
+      fs.writeFileSync(prdPath, "prd");
+      fs.writeFileSync(archPath, "arch");
+
+      const mockProcess = createMockProcess(0);
+      mockedSpawn.mockReturnValue(mockProcess);
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      const handle = spawnDevAgent({
+        area: "frontend",
+        tickets: [10, 11],
+        promptFile: promptPath,
+        prdFile: prdPath,
+        architectureFile: archPath,
+      });
+
+      expect(handle.area).toBe("frontend");
+      expect(handle.tickets).toEqual([10, 11]);
+      expect(handle.agentHandle.name).toBe("dev-frontend");
+      expect(handle.result).toBeInstanceOf(Promise);
+    });
+
+    it("should throw DevAgentError if area is empty", () => {
+      const promptPath = path.join(TEST_PROMPTS_DIR, "dev.md");
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+      fs.writeFileSync(promptPath, "prompt");
+      fs.writeFileSync(prdPath, "prd");
+      fs.writeFileSync(archPath, "arch");
+
+      expect(() =>
+        spawnDevAgent({
+          area: "",
+          tickets: [10],
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        })
+      ).toThrow(DevAgentError);
+    });
+  });
+
+  describe("runDevSessions", () => {
+    const setupTestFiles = () => {
+      const promptPath = path.join(TEST_PROMPTS_DIR, "dev.md");
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+
+      fs.writeFileSync(promptPath, "You are a Dev agent");
+      fs.writeFileSync(prdPath, "# PRD");
+      fs.writeFileSync(archPath, "# Architecture");
+
+      return { promptPath, prdPath, archPath };
+    };
+
+    it("should run multiple sessions in parallel by default", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+
+      // Create separate mock processes for each session
+      mockedSpawn
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.SUCCESS))
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.SUCCESS));
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      const results = await runDevSessions(
+        [
+          { area: "frontend", tickets: [10] },
+          { area: "backend", tickets: [20] },
+        ],
+        { promptFile: promptPath, prdFile: prdPath, architectureFile: archPath }
+      );
+
+      expect(results).toHaveLength(2);
+      expect(results[0].area).toBe("frontend");
+      expect(results[0].status).toBe("success");
+      expect(results[1].area).toBe("backend");
+      expect(results[1].status).toBe("success");
+
+      // Both spawns should have been called
+      expect(mockedSpawn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should run sessions sequentially when parallel=false", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+
+      mockedSpawn
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.SUCCESS))
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.SUCCESS));
+      mockedFindLatestUnansweredQuestion.mockReturnValue(null);
+
+      const results = await runDevSessions(
+        [
+          { area: "frontend", tickets: [10] },
+          { area: "backend", tickets: [20] },
+        ],
+        {
+          parallel: false,
+          promptFile: promptPath,
+          prdFile: prdPath,
+          architectureFile: archPath,
+        }
+      );
+
+      expect(results).toHaveLength(2);
+      expect(results[0].area).toBe("frontend");
+      expect(results[1].area).toBe("backend");
+    });
+
+    it("should return empty array for empty sessions", async () => {
+      const results = await runDevSessions([]);
+
+      expect(results).toEqual([]);
+    });
+
+    it("should handle mixed success/blocked/error results", async () => {
+      const { promptPath, prdPath, archPath } = setupTestFiles();
+
+      mockedSpawn
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.SUCCESS))
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.BLOCKED))
+        .mockReturnValueOnce(createMockProcess(EXIT_CODES.ERROR));
+
+      mockedFindLatestUnansweredQuestion
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(path.join(TEST_QUESTIONS_DIR, "q-001.md"))
+        .mockReturnValueOnce(null);
+
+      mockedParseQuestionFile.mockReturnValue({
+        filePath: "",
+        fromAgent: "dev",
+        forRecipient: "tech_lead",
+        context: "",
+        question: "",
+        options: [],
+        rawContent: "",
+      });
+      mockedRouteQuestion.mockReturnValue("spawn_tech_lead");
+
+      const results = await runDevSessions(
+        [
+          { area: "frontend", tickets: [10] },
+          { area: "backend", tickets: [20] },
+          { area: "api", tickets: [30] },
+        ],
+        { promptFile: promptPath, prdFile: prdPath, architectureFile: archPath }
+      );
+
+      expect(results).toHaveLength(3);
+      expect(results[0].status).toBe("success");
+      expect(results[1].status).toBe("blocked");
+      expect(results[2].status).toBe("error");
+    });
+  });
+
+  describe("spawnDevSessions", () => {
+    it("should spawn multiple sessions and return handles", () => {
+      const promptPath = path.join(TEST_PROMPTS_DIR, "dev.md");
+      const prdPath = path.join(TEST_ORCHESTRATOR_DIR, "prd.md");
+      const archPath = path.join(TEST_ORCHESTRATOR_DIR, "architecture.md");
+      fs.writeFileSync(promptPath, "prompt");
+      fs.writeFileSync(prdPath, "prd");
+      fs.writeFileSync(archPath, "arch");
+
+      mockedSpawn
+        .mockReturnValueOnce(createMockProcess(0))
+        .mockReturnValueOnce(createMockProcess(0));
+
+      const handles = spawnDevSessions(
+        [
+          { area: "frontend", tickets: [10] },
+          { area: "backend", tickets: [20] },
+        ],
+        { promptFile: promptPath, prdFile: prdPath, architectureFile: archPath }
+      );
+
+      expect(handles).toHaveLength(2);
+      expect(handles[0].area).toBe("frontend");
+      expect(handles[1].area).toBe("backend");
+    });
+  });
+
+  describe("Helper functions", () => {
+    describe("getBlockedSessionForTechLead", () => {
+      it("should return first blocked session needing Tech Lead", () => {
+        const results: DevAgentResult[] = [
+          {
+            area: "frontend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+          {
+            area: "backend",
+            status: "blocked",
+            agentResult: { exitCode: 2, stdout: "", stderr: "", killed: false },
+            questionFile: "/q-001.md",
+            needsTechLead: true,
+          },
+          {
+            area: "api",
+            status: "blocked",
+            agentResult: { exitCode: 2, stdout: "", stderr: "", killed: false },
+            questionFile: "/q-002.md",
+            needsTechLead: true,
+          },
+        ];
+
+        const blocked = getBlockedSessionForTechLead(results);
+
+        expect(blocked).not.toBeNull();
+        expect(blocked!.area).toBe("backend");
+      });
+
+      it("should return null when no blocked sessions need Tech Lead", () => {
+        const results: DevAgentResult[] = [
+          {
+            area: "frontend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+          {
+            area: "backend",
+            status: "blocked",
+            agentResult: { exitCode: 2, stdout: "", stderr: "", killed: false },
+            questionFile: "/q-001.md",
+            needsTechLead: false, // Routes to user, not Tech Lead
+          },
+        ];
+
+        const blocked = getBlockedSessionForTechLead(results);
+
+        expect(blocked).toBeNull();
+      });
+    });
+
+    describe("allSessionsCompleted", () => {
+      it("should return true when all sessions succeeded", () => {
+        const results: DevAgentResult[] = [
+          {
+            area: "frontend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+          {
+            area: "backend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+        ];
+
+        expect(allSessionsCompleted(results)).toBe(true);
+      });
+
+      it("should return false when any session is blocked or error", () => {
+        const results: DevAgentResult[] = [
+          {
+            area: "frontend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+          {
+            area: "backend",
+            status: "blocked",
+            agentResult: { exitCode: 2, stdout: "", stderr: "", killed: false },
+            questionFile: "/q-001.md",
+            needsTechLead: true,
+          },
+        ];
+
+        expect(allSessionsCompleted(results)).toBe(false);
+      });
+
+      it("should return true for empty results", () => {
+        expect(allSessionsCompleted([])).toBe(true);
+      });
+    });
+
+    describe("getSessionsByStatus", () => {
+      it("should filter sessions by status", () => {
+        const results: DevAgentResult[] = [
+          {
+            area: "frontend",
+            status: "success",
+            agentResult: { exitCode: 0, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+          {
+            area: "backend",
+            status: "blocked",
+            agentResult: { exitCode: 2, stdout: "", stderr: "", killed: false },
+            questionFile: "/q-001.md",
+            needsTechLead: true,
+          },
+          {
+            area: "api",
+            status: "error",
+            agentResult: { exitCode: 1, stdout: "", stderr: "", killed: false },
+            questionFile: null,
+            needsTechLead: false,
+          },
+        ];
+
+        expect(getSessionsByStatus(results, "success")).toHaveLength(1);
+        expect(getSessionsByStatus(results, "success")[0].area).toBe("frontend");
+
+        expect(getSessionsByStatus(results, "blocked")).toHaveLength(1);
+        expect(getSessionsByStatus(results, "blocked")[0].area).toBe("backend");
+
+        expect(getSessionsByStatus(results, "error")).toHaveLength(1);
+        expect(getSessionsByStatus(results, "error")[0].area).toBe("api");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement Dev agent with background mode execution (`stdio: "pipe"`) for parallel development sessions
- Add blocking escalation to Tech Lead via `checkBlockingForTechLead()` which detects questions routed to Tech Lead
- Support parallel/sequential session execution with `runDevSessions()` and `spawnDevSessions()`

## Test plan
- [x] All 214 tests passing (`npm test`)
- [x] TypeScript build passes (`npm run build`)
- [x] Dev agent tests cover success, blocked (with Tech Lead routing), and error scenarios
- [x] Parallel and sequential session execution tested
- [x] Helper functions tested: `getBlockedSessionForTechLead()`, `allSessionsCompleted()`, `getSessionsByStatus()`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)